### PR TITLE
switch to a class for channels to allow multiple instances

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sledgehammer_bindgen"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Evan Almloff <ealmlof1@stumail.jccc.edu>"]
 edition = "2021"
 description = "Fast batched js bindings"
@@ -17,6 +17,7 @@ wasm-bindgen = { version = "*", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
+getrandom = { version = "0.2", features = ["js"] }
 sledgehammer_utils = "0.2.0"
 wasm-bindgen = "0.2"
 wry = { version = "0.33.0", features = ["devtools"] }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,20 +1,9 @@
 use sledgehammer_bindgen::bindgen;
-use web_sys::Node;
 
 fn main() {
     #[bindgen]
     mod js {
         struct Channel;
-
-        const JS: &str = r#"const nodes = [document.getElementById("main")];
-        export function get_node(id){
-            return nodes[id];
-        }"#;
-
-        extern "C" {
-            #[wasm_bindgen]
-            fn get_node(u1: u8, u2: u16, u3: u32) -> Node;
-        }
 
         fn num(u1: u8, u2: u16, u3: u32) {
             "console.log($u1$, $u2$, $u3$);"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,4 +1,5 @@
 use sledgehammer_bindgen::bindgen;
+use wasm_bindgen::prelude::wasm_bindgen;
 use web_sys::{console, Node};
 
 fn main() {
@@ -6,15 +7,7 @@ fn main() {
     mod js {
         struct Channel;
 
-        const JS: &str = r#"const nodes = [document.getElementById("main")];
-        export function get_node(id){
-            return nodes[id];
-        }"#;
-
-        extern "C" {
-            #[wasm_bindgen]
-            fn get_node(id: u16) -> Node;
-        }
+        const JS: &str = r#"this.nodes = [document.getElementById("main")];"#;
 
         fn create_element(id: u16, name: &'static str<u8, name_cache>) {
             "nodes[$id$]=document.createElement($name$);"
@@ -69,6 +62,15 @@ fn main() {
         }
     }
 
+    #[wasm_bindgen(inline_js = "
+    export function get_node(channel, id){
+        return channel.nodes[id];
+    }
+")]
+    extern "C" {
+        fn get_node(node: &JSChannel, id: u16) -> Node;
+    }
+
     let mut channel1 = Channel::default();
     let main = 0;
     let node1 = 1;
@@ -80,5 +82,5 @@ fn main() {
     channel1.append_child(main, node1);
     channel1.flush();
 
-    console::log_1(&get_node(0).into());
+    console::log_1(&get_node(channel1.js_channel(), 0).into());
 }

--- a/examples/wry.rs
+++ b/examples/wry.rs
@@ -11,11 +11,8 @@ use wry::http::Response;
 mod js {
     struct Channel;
 
-    const JS: &str = r#"const nodes = [document.getElementById("main")];
-export function get_node(id){
-    return nodes[id];
-}
-const els = [
+    const JS: &str = r#"this.nodes = [document.getElementById("main")];
+this.els = [
     "a",
     "abbr",
     "acronym",
@@ -152,7 +149,7 @@ const els = [
     "xmp",
 ];
 
-const attrs = [
+this. attrs = [
     "accept-charset",
     "accept",
     "accesskey",
@@ -309,47 +306,47 @@ const attrs = [
 ];"#;
 
     fn create_element(id: u16, element_id: u8) {
-        "nodes[$id$]=document.createElement(els[$element_id$]);"
+        "this.nodes[$id$]=document.createElement(this.els[$element_id$]);"
     }
 
     fn set_attribute(id: u16, attribute_id: u8, val: impl Writable<u8>) {
-        "nodes[$id$].setAttribute(attrs[$attribute_id$],$val$);"
+        "this.nodes[$id$].setAttribute(this.attrs[$attribute_id$],$val$);"
     }
 
     fn remove_attribute(id: u16, attribute_id: u8) {
-        "nodes[$id$].removeAttribute(attrs[$attribute_id$]);"
+        "this.nodes[$id$].removeAttribute(this.attrs[$attribute_id$]);"
     }
 
     fn append_child(id: u16, id2: u16) {
-        "nodes[$id$].appendChild(nodes[$id2$]);"
+        "this.nodes[$id$].appendChild(this.nodes[$id2$]);"
     }
 
     fn insert_before(parent: u16, id: u16, id2: u16) {
-        "nodes[$parent$].insertBefore(nodes[$id$],nodes[$id2$]);"
+        "this.nodes[$parent$].insertBefore(this.nodes[$id$],this.nodes[$id2$]);"
     }
 
     fn set_text(id: u16, text: impl Writable<u8>) {
-        "nodes[$id$].textContent=$text$;"
+        "this.nodes[$id$].textContent=$text$;"
     }
 
     fn remove(id: u16) {
-        "nodes[$id$].remove();"
+        "this.nodes[$id$].remove();"
     }
 
     fn replace(id: u16, id2: u16) {
-        "nodes[$id$].replaceWith(nodes[$id2$]);"
+        "this.nodes[$id$].replaceWith(this.nodes[$id2$]);"
     }
 
     fn clone(id: u16, id2: u16) {
-        "nodes[$id2$]=nodes[$id$].cloneNode(true);"
+        "this.nodes[$id2$]=this.nodes[$id$].cloneNode(true);"
     }
 
     fn first_child(id: u16) {
-        "node[id]=node[id].firstChild;"
+        "this.node[id]=this.node[id].firstChild;"
     }
 
     fn next_sibling(id: u16) {
-        "node[id]=node[id].nextSibling;"
+        "this.node[id]=this.node[id].nextSibling;"
     }
 }
 
@@ -679,12 +676,13 @@ fn main() -> wry::Result<()> {
                         <div id="main"></div>
                         <script>
                             {}
+                            let channel = new JSChannel();
                             function wait_for_request() {{
                                 fetch(new Request("dioxus://index.html"))
                                     .then(response => {{
                                         response.arrayBuffer()
                                             .then(bytes => {{
-                                                run_from_bytes(bytes);
+                                                channel.run_from_bytes(bytes);
                                                 wait_for_request();
                                             }});
                                     }})

--- a/sledgehammer_bindgen_macro/src/builder.rs
+++ b/sledgehammer_bindgen_macro/src/builder.rs
@@ -40,7 +40,7 @@ impl BindingBuilder {
     }
 
     pub fn pre_run_js(&self) -> String {
-        "metaflags=m.getUint32(d,true);".to_string()
+        "this.metaflags=this.m.getUint32(this.d,true);".to_string()
     }
 }
 
@@ -50,7 +50,7 @@ pub struct RustJSU32 {
 
 impl RustJSU32 {
     pub fn read_js(&self) -> String {
-        format!("m.getUint32(d+{}*4,true)", self.id + 1)
+        format!("this.m.getUint32(this.d+{}*4,true)", self.id + 1)
     }
 
     pub fn write_rust(&self, value: Expr) -> TokenStream2 {
@@ -76,7 +76,7 @@ pub struct RustJSFlag {
 
 impl RustJSFlag {
     pub fn read_js(&self) -> String {
-        select_bits_js_inner("metaflags", 32, self.id, 1)
+        select_bits_js_inner("this.metaflags", 32, self.id, 1)
     }
 
     pub fn write_rust(&self, value: Expr) -> TokenStream2 {

--- a/sledgehammer_bindgen_macro/src/encoder.rs
+++ b/sledgehammer_bindgen_macro/src/encoder.rs
@@ -14,7 +14,7 @@ pub trait CreateEncoder {
 }
 
 pub trait Encoder {
-    fn global_js(&self) -> String {
+    fn initializer(&self) -> String {
         String::new()
     }
 
@@ -84,8 +84,8 @@ impl EncodeTraitObject {
 }
 
 impl Encoder for EncodeTraitObject {
-    fn global_js(&self) -> String {
-        self.0.global_js()
+    fn initializer(&self) -> String {
+        self.0.initializer()
     }
 
     fn pre_run_js(&self) -> String {

--- a/sledgehammer_bindgen_macro/src/types/slice.rs
+++ b/sledgehammer_bindgen_macro/src/types/slice.rs
@@ -57,16 +57,16 @@ impl<const N: u32, const S: u32, const STATIC: bool> Encode for Slice<N, S, STAT
         let len_read = self.len.encode_js();
         if STATIC {
             match N {
-                1 => format!("new Uint8Array(m.buffer,{},{})", ptr_read, len_read),
-                2 => format!("new Uint16Array(m.buffer,{},{})", ptr_read, len_read),
-                4 => format!("new Uint32Array(m.buffer,{},{})", ptr_read, len_read),
+                1 => format!("new Uint8Array(this.m.buffer,{},{})", ptr_read, len_read),
+                2 => format!("new Uint16Array(this.m.buffer,{},{})", ptr_read, len_read),
+                4 => format!("new Uint32Array(this.m.buffer,{},{})", ptr_read, len_read),
                 _ => todo!(),
             }
         } else {
             let array_ptr = self.array().pointer_js();
             let array_read = self.array().js_ident();
             let slice_end = format!("{array_ptr}+{len_read}");
-            format!("(()=>{{e={slice_end};const final_array = {array_read}.slice({array_ptr},e);{array_ptr}=e;return final_array;}})()")
+            format!("(()=>{{this.e={slice_end};const final_array = {array_read}.slice({array_ptr},this.e);{array_ptr}=this.e;return final_array;}})()")
         }
     }
 

--- a/sledgehammer_bindgen_macro/src/types/writable.rs
+++ b/sledgehammer_bindgen_macro/src/types/writable.rs
@@ -46,7 +46,10 @@ impl<const S: u32> Encoder for WritableEncoder<S> {
 
 impl<const S: u32> Encode for WritableEncoder<S> {
     fn encode_js(&self) -> String {
-        format!("s.substring(sp,sp+={})", self.size_type.encode_js())
+        format!(
+            "this.s.substring(this.sp,this.sp+={})",
+            self.size_type.encode_js()
+        )
     }
 
     fn encode_rust(&self, name: &Ident) -> TokenStream2 {


### PR DESCRIPTION
This PR enables multiple instances of the same interpreter by using a class instead of globals