### PR TITLE
Inline some parameters even if some arguments are unknown

### DIFF
--- a/sledgehammer_bindgen_macro/src/types/slice.rs
+++ b/sledgehammer_bindgen_macro/src/types/slice.rs
@@ -71,9 +71,9 @@ impl<const N: u32, const S: u32, const STATIC: bool> Encode for Slice<N, S, STAT
     }
 
     fn encode_rust(&self, ident: &Ident) -> TokenStream2 {
-        let len = Ident::new("len", Span::call_site());
+        let len = Ident::new("__len", Span::call_site());
         let encode_len = self.len.encode_rust(&len);
-        let ptr = Ident::new("ptr", Span::call_site());
+        let ptr = Ident::new("__ptr", Span::call_site());
         let encode_ptr = self.ptr.encode_rust(&ptr);
         let write_array = (!STATIC).then(|| {
             let item = Ident::new("_i", Span::call_site());

--- a/sledgehammer_bindgen_macro/src/types/string.rs
+++ b/sledgehammer_bindgen_macro/src/types/string.rs
@@ -266,8 +266,8 @@ impl<const S: u32> Encode for StrEncoder<S> {
     }
 
     fn encode_rust(&self, name: &Ident) -> TokenStream2 {
-        let len = Ident::new("len", Span::call_site());
-        let char_len = Ident::new("char_len", Span::call_site());
+        let len = Ident::new("__len", Span::call_site());
+        let char_len = Ident::new("__char_len", Span::call_site());
         let write_len = self.size_type.encode_rust(&char_len);
         let char_len_type = self.size_type().element_type();
         let encode = quote! {


### PR DESCRIPTION
This optimizes inline-able arguments slightly better. Currently arguments are only inlined if all arguments can be inlined. This PR allows sledgehammer to only inline some of the arguments. In order to support this, sledgehammer now encodes arguments that are read at an unknown time first and then encodes inlined arguments in the order we see them in the function