### PR TITLE
Replace HashMap with BTreeMap to avoid unreproducible builds

### DIFF
--- a/sledgehammer_bindgen_macro/src/encoder.rs
+++ b/sledgehammer_bindgen_macro/src/encoder.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, collections::HashMap, ops::Deref, rc::Rc};
+use std::{any::Any, collections::BTreeMap, ops::Deref, rc::Rc};
 
 use quote::{__private::TokenStream as TokenStream2, quote};
 use syn::{Ident, Type};
@@ -137,12 +137,12 @@ impl Encode for EncodeTraitObject {
 
 #[derive(Default)]
 pub struct Encoders {
-    encoders: HashMap<Ident, EncodeTraitObject>,
+    encoders: BTreeMap<Ident, EncodeTraitObject>,
     pub(crate) builder: BindingBuilder,
 }
 
 impl Deref for Encoders {
-    type Target = HashMap<Ident, EncodeTraitObject>;
+    type Target = BTreeMap<Ident, EncodeTraitObject>;
 
     fn deref(&self) -> &Self::Target {
         &self.encoders

--- a/sledgehammer_bindgen_macro/src/lib.rs
+++ b/sledgehammer_bindgen_macro/src/lib.rs
@@ -57,7 +57,7 @@ use function::FunctionBinding;
 use proc_macro::TokenStream;
 use quote::__private::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use std::{collections::HashSet, ops::Deref};
+use std::{collections::BTreeSet, ops::Deref};
 use syn::spanned::Spanned;
 use syn::{parse::Parse, parse_macro_input, Ident};
 use syn::{parse_quote, Token};
@@ -317,7 +317,7 @@ impl Bindings {
 
         let pre_run_metadata = self.encoders.builder().pre_run_js();
 
-        let all_variables: HashSet<&str> = self
+        let all_variables: BTreeSet<&str> = self
             .functions
             .iter()
             .flat_map(|f| f.variables.iter().map(|s| s.as_str()))


### PR DESCRIPTION
I'm hoping that this doesn't need much explanation or motivation, so I'll stay overly brief. If you'd like me to elaborate, please do tell.

* Explanation:  The mapping of  `HashMap` is deliberately randomized to avoid DoS, and thus is the output order of iterating over hash map elements. This generated different js with each invocation of the macro.
* Motivation: I'm building an FF Add-on / web extension based on dioxus, and when submitting that to mozilla for a signature (using unsigned add-ons is deliberately made very inconvenient), having the submitted extension be reproducible from source is a requirement.

I have verified that I can create reproducible builds with this change, and not without it.